### PR TITLE
Overwrite Metadata of container

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -10,6 +10,13 @@ RUN apk add --no-cache --virtual .build-deps \
 # Final stage
 FROM dunglas/frankenphp:1.9.0-php8.4.10-alpine
 
+# Overwrite some labels from FrankenPHP
+LABEL org.opencontainers.image.title="Upvote RSS"
+LABEL org.opencontainers.image.description="Generate rich RSS feeds from Reddit, Hacker News, Lemmy, Mbin, and more"
+LABEL org.opencontainers.image.url="https://www.upvote-rss.com/"
+LABEL org.opencontainers.image.source="https://github.com/johnwarne/upvote-rss"
+LABEL org.opencontainers.image.licenses="MIT"
+
 # Install su-exec and opcache
 RUN apk add --no-cache su-exec && \
     install-php-extensions gd opcache apcu


### PR DESCRIPTION
FrankenPHP sets metadata/labels (see https://hub.docker.com/layers/dunglas/frankenphp/1.9.0-php8.4.10-alpine/images/sha256-fe62e6ece79fefcccf88c439ca90e3590092eba48cb4d027d064367659fac11d). As this image is based on FrankenPHP, that metadata should be overwritten; some tools might get confused otherwise. 

e.g. Renovate:
<img width="1229" height="1052" alt="image" src="https://github.com/user-attachments/assets/bac2060e-a46b-4461-8014-442c99eefecd" />

You might also want to overwrite org.opencontainers.image.vendor (as that is set by FrankenPHP), but that is up to you. Other information about annotations: https://github.com/opencontainers/image-spec/blob/main/annotations.md